### PR TITLE
remove open PRs from planning board

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
 
-
 jobs:
   add_to_project:
     if: '!github.event.repository.fork'

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
 
+
 jobs:
   add_to_project:
     if: '!github.event.repository.fork'

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request_target:
-    types:
-      - opened
 
 jobs:
   add_to_project:


### PR DESCRIPTION
### Description

Remove "Open PRs" from planning board. 
```
Run actions/add-to-project@v0.3.0
Creating project item
Error: Request failed due to following response errors:
Projects cannot have more than 1200 items. To add more, please archive or delete existing items.
```

Xref #696 