### PR TITLE
Remove conda/actions from releases sync

### DIFF
--- a/.github/sync/config.yml
+++ b/.github/sync/config.yml
@@ -53,7 +53,6 @@ group:
         dest: HOW_WE_USE_GITHUB.md
   # projects with releases
   - repos: |
-      conda/actions
       conda/conda
       conda/conda-benchmarks
       conda/conda-build
@@ -81,6 +80,7 @@ group:
   # projects without releases
   - repos: |
       conda/.github
+      conda/actions
       conda/conda-plugin-template
       conda/issue-tracker
     files:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While conda/actions have releases, they're not the same as rever releases, so there's no value in syncing the rever release instructions, the news snippet template, or the associated PR template.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
