### PR TITLE
Rename sprint label to in-progress (issue #701)

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -41,6 +41,7 @@
 - name: in-progress
   description: issue is actively being worked on
   color: "ededed"
+  aliases: [sprint]
 - name: spike
   description: issue is for doing research work or prototyping; outcome is optional and not required
   color: "ededed"

--- a/.github/global.yml
+++ b/.github/global.yml
@@ -38,8 +38,8 @@
   description: issue has been triaged but has not been earmarked for any upcoming release
   color: "ededed"
   aliases: [1_Backlog_Long_Term]
-- name: sprint
-  description: issue has been pulled into current sprint and is actively being worked on
+- name: in-progress
+  description: issue is actively being worked on
   color: "ededed"
 - name: spike
   description: issue is for doing research work or prototyping; outcome is optional and not required

--- a/HOW_WE_USE_GITHUB.md
+++ b/HOW_WE_USE_GITHUB.md
@@ -6,7 +6,7 @@
 [project-sorting]: https://github.com/orgs/conda/projects/2/views/11
 [project-support]: https://github.com/orgs/conda/projects/2/views/12
 [project-backlog]: https://github.com/orgs/conda/projects/2/views/13
-[project-sprint]: https://github.com/orgs/conda/projects/2/views/14
+[project-in-progress]: https://github.com/orgs/conda/projects/2/views/14
 
 [docs-toc]: https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/
 [docs-actions]: https://docs.github.com/en/actions
@@ -58,8 +58,8 @@ flowchart LR
         board_backlog-- refine -->board_backlog
     end
 
-    subgraph flow_sprint [Sprint]
-        board_sprint{{Sprint}}
+    subgraph flow_progress [In Progress]
+        board_progress{{In Progress}}
     end
 
     state_new(New Issues)
@@ -69,9 +69,9 @@ flowchart LR
     board_sorting-- investigated -->board_backlog
     board_sorting-- duplicates, off-topic -->state_closed
     board_support-- resolved, unresponsive -->state_closed
-    board_backlog-- pending work -->board_sprint
+    board_backlog-- pending work -->board_progress
     board_backlog-- resolved, irrelevant -->state_closed
-    board_sprint-- resolved -->state_closed
+    board_progress-- resolved -->state_closed
 ```
 
 In order to explain how various `conda` issues are evaluated, the following document will provide information about our sorting process in the form of an FAQ.
@@ -129,21 +129,12 @@ The additional tabs in the project board that the issues can be moved to include
 
 All sorted issues will be reviewed by sorting engineers during a weekly Refinement meeting in order to understand how those particular issues fit into the short- and long-term roadmap of `conda`. These meetings enable the sorting engineers to get together to collectively prioritize issues, earmark feature requests for specific future releases (versus a more open-ended backlog), tag issues as ideal for first-time contributors, as well as whether or not to close/reject specific feature requests.
 
-Once issues are deemed ready to be worked on, they will be moved to the [`conda` Backlog tab of the Planning board][project-backlog] on GitHub. Once actively in progress, the issues will be moved to the [Sprint tab of the Planning board][project-sprint] and then closed out once the work is complete.
+Once issues are deemed ready to be worked on, they will be moved to the [`conda` Backlog tab of the Planning board][project-backlog] on GitHub. Once actively in progress, the issues will be moved to the [In Progress tab of the Planning board][project-in-progress] and then closed out once the work is complete.
 
 
 #### What is the purpose of having a "Backlog"?
 
 Issues are "backlogged" when they have been sorted but not yet earmarked for an upcoming release. Weekly Refinement meetings are a time when the `conda` engineers will transition issues from "[Sorting][project-sorting]" to "[Backlog][project-backlog]". Additionally, this time of handoff will include discussions around the kind of issues that were raised, which provides an opportunity to identify any patterns that may point to a larger problem.
-
-
-#### What is the purpose of a "development sprint"?
-
-After issues have been sorted and backlogged, they will eventually be moved into the "Sprint Candidate", "Short-Term", "Medium-Term", "Long-Term", or "No Time Frame" sections of the [Backlog tab of the Planning board][project-backlog] and get one or more sprint cycles dedicated to them.
-
-The purpose of a development sprint is to enable a steady delivery of enhancements, features, and bug fixes by setting aside pre-determined portions of time that are meant for focusing on specifically-assigned items.
-
-Sprints also serve to focus the engineering team's attention on more accurate planning for what is to come during the entire release cycle, as well as keep the scope of development work concise. They enable the setting aside of dedicated time for the engineers to resolve any problems with the work involved, instead of pushing these problems to the end of the release cycle when there may not be any time remaining to fix issues.
 
 
 #### How does labeling work?

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Welcome others and be open-minded. Remember that this is a community we build to
 ## GitHub Workflows
 
 We have defined a number of GitHub Workflows that are synced out to other repos within the Conda GitHub Org. These workflows accomplish:
-  * 🤖 Automation used for Issue Sorting/Backlog/Sprint project boards
+  * 🤖 Automation used for Issue Sorting/Support/Backlog/Kanban project boards
   * 🏷️ Label standardization
   * 🔒 Marking issues & PRs as stale, closing stale items, and locking inactive items
   * 🔄 Dispersing workflow changes to other repos

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Welcome others and be open-minded. Remember that this is a community we build to
 ## GitHub Workflows
 
 We have defined a number of GitHub Workflows that are synced out to other repos within the Conda GitHub Org. These workflows accomplish:
-  * 🤖 Automation used for Issue Sorting/Support/Backlog/Kanban project boards
+  * 🤖 Automation used for project boards
   * 🏷️ Label standardization
   * 🔒 Marking issues & PRs as stale, closing stale items, and locking inactive items
   * 🔄 Dispersing workflow changes to other repos


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Resolves issue #701 by renaming `sprint` label to `in-progress` and removing reference to sprint in description. Also includes updates to `readme` and `How We Use GitHub` documents to remove references to sprints.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Tasks:

- [x] Global label config updated (`global.yml`)
- [x] `README.md` updated
- [x] `HOW_WE_USE_GITHUB.md` updated
- [x] `Kanban` project board name updated to `In Progress`

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
