### PR TITLE
Shorten duplicate label descriptions

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -53,14 +53,11 @@
 
 # Duplicates
 - name: duplicate
-  description: >
-    can be used for issues or pull requests (PRs) to indicate that the tagged issue/PR
-    is a duplicate of another issue/PR: e.g., issue/PR covers the same concerns as another issue/PR,
-    PR resolves the same issue as another PR, etc.
+  description: indicate issues/PRs that are duplicates of another
   color: "0c2132"
   aliases: [reso-duplicate, "reso:duplicate"]
 - name: duplicate::primary
-  description: if an issue or pull request has duplicates, this is the consolidated, primary issue/pull request
+  description: if an issue/PR has duplicates, this is the consolidated, primary issue/PR
   color: "0c2132"
   aliases: [consolidation-main]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

When attempting to run the label syncing I get the following error:
<img width="678" alt="Screenshot 2023-03-21 at 10 58 29 AM" src="https://user-images.githubusercontent.com/4546435/226666997-dfe8d6ca-ce91-401f-a119-032d4917b50e.png">

So I've sought to remove verbose language

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
