### PR TITLE
Update rever.xsh to avoid unwanted newline

### DIFF
--- a/.github/sync/rever.xsh
+++ b/.github/sync/rever.xsh
@@ -1,7 +1,7 @@
 $ACTIVITIES = ["authors", "changelog"]
 
 # Basic settings
-$PROJECT = $GITHUB_REPO = $(basename $(git remote get-url origin)).split('.')[0]
+$PROJECT = $GITHUB_REPO = $(basename $(git remote get-url origin)).split('.')[0].strip()
 $GITHUB_ORG = "conda"
 
 # Authors settings


### PR DESCRIPTION
strip project name to avoid newline

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Without this, we see "This project, conda

." with a newline or two between the project name and the period.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
