### PR TITLE
Update `good-first-issue` to `good first issue` so GH recognizes it

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -2,10 +2,12 @@
 - name: mitigated
   description: a workaround has been identified
   color: "43b049"
-- name: good-first-issue
+# this doesn't follow our labeling style because GitHub only populates the
+# https://github.com/conda/conda/contribute page with this exact label
+- name: good first issue
   description: great for new contributors, code change is envisioned to be trivial/relatively straight-forward
   color: "43b049"
-  aliases: ["good first issue"]
+  aliases: ["good-first-issue"]
 - name: help-wanted
   description: we don't know the solution or we especially want a community member to contribute the code change
   color: "43b049"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

GitHub offers a `/contribute` page for every repo which curates all issues using the `good first issue` label. We need to update our label (`good-first-issue`) to match the expected label.

Resolves #727

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
