### PR TITLE
Remove invalid actions/stale input

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -69,8 +69,6 @@ jobs:
           stale-pr-label: stale
           # Label to apply on closed PRs
           close-pr-label: stale::closed
-          # Reason to use when closing PRs
-          close-pr-reason: not_planned
 
           # Remove stale label from issues/PRs on updates/comments
           remove-stale-when-updated: true


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`close-pr-reason` is actually not a valid input to the `actions/stale` GH Action. We keep getting warnings:

<img width="816" alt="Screenshot 2023-06-12 at 11 02 24 PM" src="https://github.com/conda/infrastructure/assets/4546435/f92e0eaa-35e4-4e72-a617-b338b7b71847">

This was an accidental copy/paste of the `close-issue-reason` added in https://github.com/conda/infrastructure/pull/710

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
