### PR TITLE
Add rever release to `conda-content-trust`

### DIFF
--- a/.github/sync/config.yml
+++ b/.github/sync/config.yml
@@ -92,8 +92,9 @@ group:
   - repos: |
       conda/conda
       conda/conda-build
-      conda/conda-package-handling
+      conda/conda-content-trust
       conda/conda-libmamba-solver
+      conda/conda-package-handling
     files:
       # rever config
       - source: .github/sync/rever.xsh


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Sync out rever and release docs to conda-content-trust.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
