### PR TITLE
Remove news snippets from conda-docs

### DIFF
--- a/.github/sync/config.yml
+++ b/.github/sync/config.yml
@@ -58,7 +58,6 @@ group:
       conda/conda-benchmarks
       conda/conda-build
       conda/conda-content-trust
-      conda/conda-docs
       conda/conda-index
       conda/conda-libmamba-solver
       conda/conda-pack
@@ -82,6 +81,7 @@ group:
   - repos: |
       conda/.github
       conda/actions
+      conda/conda-docs
       conda/conda-plugin-template
       conda/issue-tracker
     files:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

conda-docs doesn't have releases so the news snippets serve no purpose.

https://github.com/conda/conda-docs/pull/910 removes unused news snippets.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
