### PR TITLE
Update YAML files to adhere to the latest pre-commit CI standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -32,9 +32,7 @@ body:
     attributes:
       label: Summary
       description: >-
-        Define the highlevel objectives to be accomplished in this epic. Include the
-        bigger picture of what is changing and/or the user story for why the
-        changes are desired/necessary.
+        Define the highlevel objectives to be accomplished in this epic. Include the bigger picture of what is changing and/or the user story for why the changes are desired/necessary.
     validations:
       required: true
   - type: textarea

--- a/.github/global.yml
+++ b/.github/global.yml
@@ -3,8 +3,8 @@
   - name: mitigated
     description: a workaround has been identified
     color: '#43b049'
-  # this doesn't follow our labeling style because GitHub only populates the
-  # https://github.com/conda/conda/contribute page with this exact label
+# this doesn't follow our labeling style because GitHub only populates the
+# https://github.com/conda/conda/contribute page with this exact label
   - name: good first issue
     description: great for new contributors, code change is envisioned to be trivial/relatively straight-forward
     color: '#43b049'
@@ -30,8 +30,7 @@
       - reso-wontfix
       - wontfix
       - reso:wontfix
-
-# Bots
+    # Bots
   - name: cla-signed
     description: '[bot] added once the contributor has signed the CLA'
     color: '#ededed'
@@ -41,8 +40,7 @@
   - name: dependencies
     description: '[bot] PRs that update a dependency file'
     color: '#0366d6'
-
-# Planning
+  # Planning
   - name: epic
     description: a highlevel collection of smaller related issues
     color: '#ededed'
@@ -57,13 +55,11 @@
   - name: spike
     description: issue is for doing research work or prototyping; outcome is optional and not required
     color: '#ededed'
-
-# Sync
+  # Sync
   - name: sync::anaconda
     description: sync internally with Anaconda, Inc. ticket tracker
     color: '#5B2B76'
-
-# Duplicates
+  # Duplicates
   - name: duplicate
     description: indicate issues/PRs that are duplicates of another
     color: '#0c2132'
@@ -74,8 +70,7 @@
     description: if an issue/PR has duplicates, this is the consolidated, primary issue/PR
     color: '#0c2132'
     aliases: [consolidation-main]
-
-# Pending
+  # Pending
   - name: pending::feedback
     description: indicates we are waiting on feedback from the user
     color: '#d4c5f9'
@@ -93,8 +88,7 @@
   - name: pending::support
     description: indicates user is waiting on support from triage engineers
     color: '5319E7'
-
-# Modifiers
+  # Modifiers
   - name: ¡blocking!
     description: used to indicate a blocker for a pending release
     color: '#b60205'
@@ -110,8 +104,7 @@
     description: used to indicate particularly notable information
     color: '#b60205'
     aliases: [type-advisory]
-
-# Types
+  # Types
   - name: type::bug
     description: describes erroneous operation, use severity::* to classify the type
     color: '#b60205'
@@ -162,8 +155,7 @@
   - name: type::deprecation
     description: requests removal of deprecated feature(s)
     color: '#fff2cc'
-
-# Severity
+  # Severity
   - name: severity::1
     description: blocker; broken functionality with no workaround
     color: '#b60205'
@@ -179,8 +171,7 @@
   - name: severity::4
     description: low; functionality is inconvenient
     color: '#43b04b'
-
-# Source
+  # Source
   - name: source::governance
     description: created by members of the conda governance (https://github.com/conda-incubator/governance)
     color: '#c2e0c6'
@@ -220,8 +211,7 @@
     aliases:
       - source-community
       - source:public
-
-# OS
+    # OS
   - name: os::linux
     description: relevant to Linux
     color: '#d0e0e3'
@@ -247,8 +237,7 @@
   - name: os::wsl
     description: relevant to Windows Subsystem for Linux
     color: '#d0e0e3'
-
-# Stale
+  # Stale
   - name: stale
     description: '[bot] marked as stale due to inactivity'
     color: '#E79676'
@@ -259,8 +248,7 @@
   - name: stale::closed
     description: '[bot] closed after being marked as stale'
     color: '#86A8D8'
-
-# Hackathons
+  # Hackathons
   - name: hack::HackIllinois2019
     description: issues found or suggested changes proposed during HackIllinois2019
     color: '#6ce29e'
@@ -272,8 +260,7 @@
   - name: hack::SciPy2022
     description: issues found or suggested changes proposed during SciPy2022
     color: '#6ce29e'
-
-# Tags
+  # Tags
   - name: tag::performance
     description: related to degraded performance
     color: '#86C579'
@@ -290,8 +277,7 @@
   - name: tag::ux
     description: related to user experience
     color: '#86C579'
-
-# Documentation
+  # Documentation
   - name: documentation::tutorials
     description: related to tutorials (learning-oriented)
     color: '#77b2dc'
@@ -304,8 +290,7 @@
   - name: documentation::explanation
     description: related to higher-level clarification (understanding-oriented)
     color: '#77b2dc'
-
-# Upstream & Downstream
+  # Upstream & Downstream
   - name: upstream
     description: this issue/PR is caused by an upstream dependency
     color: '#85a3ad'

--- a/.github/messages.yml
+++ b/.github/messages.yml
@@ -30,7 +30,6 @@ lock-issue: |
   Please open a new issue if needed.
 
   Thanks!
-
 stale-pr: |
   Hi there, thank you for your contribution!
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,17 +1,15 @@
 ---
 name: CLA
-
 on:
   issue_comment:
     types:
       - created
   pull_request_target:
-
 jobs:
   check:
     if: >-
-      !github.event.repository.fork
-      && (
+      !github.event.repository.fork && (
+
         github.event.issue.pull_request
         && github.event.comment.body == '@conda-bot check'
         || github.event_name == 'pull_request_target'
@@ -29,7 +27,6 @@ jobs:
           # [required]
           # Label to apply to contributor's PR once CLA is signed
           label: cla-signed
-
           # [required]
           # Token for opening signee PR in the provided `cla_repo`
           # (`pull_request: write` for fine-grained PAT; `repo` and `workflow` for classic PAT)

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,16 +1,13 @@
 ---
 name: Automate Issues
-
 on:
   # NOTE: github.event is issue_comment payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
   issue_comment:
     types: [created]
-
 env:
   FEEDBACK_LBL: pending::feedback
   SUPPORT_LBL: pending::support
-
 jobs:
   # NOTE: will update label if anyone responds, not just the author/reporter
   # TODO: create conda-issue-sorting team and modify this to toggle label based on
@@ -18,9 +15,7 @@ jobs:
   pending_support:
     # if [pending::feedback] and anyone responds
     if: >-
-      !github.event.repository.fork
-      && !github.event.issue.pull_request
-      && contains(github.event.issue.labels.*.name, 'pending::feedback')
+      !github.event.repository.fork && !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'pending::feedback')
     runs-on: ubuntu-latest
     steps:
       # remove [pending::feedback]

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,6 +1,5 @@
 ---
 name: Sync Labels
-
 on:
   # NOTE: github.event is workflow_dispatch payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
@@ -11,7 +10,6 @@ on:
         required: true
         type: boolean
         default: true
-
 jobs:
   sync:
     if: '!github.event.repository.fork'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,18 +1,14 @@
 ---
 name: Lock
-
 on:
   # NOTE: github.event is workflow_dispatch payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
   workflow_dispatch:
-
   schedule:
     - cron: 0 6 * * *
-
 permissions:
   issues: write
   pull-requests: write
-
 jobs:
   lock:
     if: '!github.event.repository.fork'
@@ -30,7 +26,6 @@ jobs:
           add-issue-labels: locked
           # Reason for locking an issue, value must be one of resolved, off-topic, too heated, spam or ''
           issue-lock-reason: resolved
-
           # Number of days of inactivity before a closed pull request is locked
           pr-inactive-days: 365
           # Do not lock pull requests created before a given timestamp, value must follow ISO 8601
@@ -41,6 +36,5 @@ jobs:
           add-pr-labels: locked
           # Reason for locking a pull request, value must be one of resolved, off-topic, too heated, spam or ''
           pr-lock-reason: resolved
-
           # Limit locking to issues, pull requests or discussions, value must be a comma separated list of issues, prs, discussions or ''
           process-only: issues, prs

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,6 +1,5 @@
 ---
 name: Add to Project
-
 on:
   issues:
     types:
@@ -8,7 +7,6 @@ on:
   pull_request_target:
     types:
       - opened
-
 jobs:
   add_to_project:
     if: '!github.event.repository.fork'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,5 @@
 ---
 name: Stale
-
 on:
   # NOTE: github.event is workflow_dispatch payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
@@ -11,14 +10,11 @@ on:
         required: true
         type: boolean
         default: true
-
   schedule:
     - cron: 0 4 * * *
-
 permissions:
   issues: write
   pull-requests: write
-
 jobs:
   stale:
     if: '!github.event.repository.fork'
@@ -38,13 +34,11 @@ jobs:
         id: read_yaml
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml
-
       - uses: actions/stale@v9
         id: stale
         with:
           # Only issues with these labels are checked whether they are stale
           only-issue-labels: ${{ matrix.only-issue-labels }}
-
           # Idle number of days before marking issues stale
           days-before-issue-stale: ${{ matrix.days-before-issue-stale }}
           # Idle number of days before closing stale issues/PRs
@@ -53,7 +47,6 @@ jobs:
           days-before-pr-stale: 365
           # Idle number of days before closing stale PRs
           days-before-pr-close: 30
-
           # Comment on the staled issues
           stale-issue-message: ${{ fromJSON(steps.read_yaml.outputs.value)['stale-issue'] }}
           # Label to apply on staled issues
@@ -62,21 +55,18 @@ jobs:
           close-issue-label: stale::closed
           # Reason to use when closing issues
           close-issue-reason: not_planned
-
           # Comment on the staled PRs
           stale-pr-message: ${{ fromJSON(steps.read_yaml.outputs.value)['stale-pr'] }}
           # Label to apply on staled PRs
           stale-pr-label: stale
           # Label to apply on closed PRs
           close-pr-label: stale::closed
-
           # Remove stale label from issues/PRs on updates/comments
           remove-stale-when-updated: true
           # Add specified labels to issues/PRs when they become unstale
           labels-to-add-when-unstale: stale::recovered
           # Remove specified labels to issues/PRs when they become unstale
           labels-to-remove-when-unstale: stale,stale::closed
-
           # Max number of operations per run
           operations-per-run: ${{ secrets.STALE_OPERATIONS_PER_RUN || 100 }}
           # Dry-run
@@ -85,7 +75,6 @@ jobs:
           ascending: true
           # Delete branch after closing a stale PR
           delete-branch: false
-
           # Issues with these labels will never be considered stale
           exempt-issue-labels: stale::recovered,epic
           # Issues with these labels will never be considered stale
@@ -94,6 +83,5 @@ jobs:
           exempt-all-milestones: true
           # Assignees on issues/PRs exempted from stale
           exempt-assignees: mingwandroid
-
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,6 +1,5 @@
 ---
 name: Sync
-
 on:
   # NOTE: github.event is push payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
@@ -13,7 +12,7 @@ on:
       - .github/ISSUE_TEMPLATE/2_documentation.yml
       - .github/PULL_REQUEST_TEMPLATE/with_releases.md
       - .github/PULL_REQUEST_TEMPLATE/without_releases.md
-      - .github/sync/config.yml  # trigger sync if config is modified
+      - .github/sync/config.yml # trigger sync if config is modified
       - .github/sync/RELEASE.md
       - .github/sync/rever.xsh
       - .github/sync/TEMPLATE
@@ -23,14 +22,12 @@ on:
       - .github/workflows/lock.yml
       - .github/workflows/project.yml
       - .github/workflows/stale.yml
-      - .github/workflows/sync.yml  # trigger sync if workflow is modified
+      - .github/workflows/sync.yml # trigger sync if workflow is modified
       - CODE_OF_CONDUCT.md
       - HOW_WE_USE_GITHUB.md
-
   # NOTE: github.event is workflow_dispatch payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
   workflow_dispatch:
-
 jobs:
   sync:
     if: '!github.event.repository.fork'


### PR DESCRIPTION
There are non-autofixable formatting failures showing up in CI runs (see [this one](https://results.pre-commit.ci/run/github/401637189/1709226036.kYi9b3jRRc-X_GSIj8aWIw) as an example); this PR _should_ update all YAML files as necessary per [latest `[pre-commit-hook-yamlfmt]` standards](https://github.com/jumanjihouse/pre-commit-hook-yamlfmt).