### PR TITLE
Add `git-diff` hook to pre-commit CI runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,11 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: local
+    hooks:
+      - id: git-diff
+        name: git diff
+        entry: git diff --exit-code
+        language: system
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
It would be helpful to see the `diff` for any pre-commit CI run changes; adding this as part of the pre-commit workflow.