### PR TITLE
Update miniconda link for `HOW_WE_USE_GITHUB.md`

### DIFF
--- a/HOW_WE_USE_GITHUB.md
+++ b/HOW_WE_USE_GITHUB.md
@@ -225,7 +225,7 @@ This is a duplicate of <b>[link to primary issue]</b>; please feel free to conti
 <pre>
 
 Please uninstall your current version of `conda` and reinstall the latest version.
-Feel free to use either the [miniconda](https://docs.conda.io/en/latest/miniconda.html)
+Feel free to use either the [miniconda](https://docs.anaconda.com/free/miniconda/)
 or [anaconda](https://www.anaconda.com/products/individual) installer,
 whichever is more appropriate for your needs.
 </pre>


### PR DESCRIPTION
While testing conda's `24.3.x` release I noticed that one of the changes from [Updating Miniconda links #13572 PR](https://github.com/conda/conda/pull/13572) was reverted due to a document that's synced from this repo. This PR updates the miniconda link correctly on here so that any repos that have the `HOW_WE_USE_GITHUB.md` document will get synced/updated properly.