### PR TITLE
Fix action-remove-labels version number

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # remove [pending::feedback]
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.2.0
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: ${{ env.FEEDBACK_LBL }}
           github_token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
### Description

The hash for `action-remove-labels` points to v1.3.0, not v1.2.0: https://github.com/actions-ecosystem/action-remove-labels/releases/tag/v1.3.0
