### PR TITLE
Remove conda specific reference for commit signing in `HWUG.md`

### DIFF
--- a/templates/HOW_WE_USE_GITHUB.md
+++ b/templates/HOW_WE_USE_GITHUB.md
@@ -267,8 +267,7 @@ In order to not have to manually type or copy/paste the above repeatedly, note t
 
 ## Commit Signing
 
-For all conda maintainers, we require commit signing and strongly recommend it for all others wishing to contribute to conda
-related projects. More information about how to set this up within GitHub can be found here:
+For all maintainers, we require commit signing and strongly recommend it for all others wishing to contribute. More information about how to set this up within GitHub can be found here:
 
 - [GitHub's signing commits docs][docs-commit-signing]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Replace "conda maintainers" with "maintainers".

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
