### PR TITLE
Use `canary_channel` instead of `canary-channel`

### DIFF
--- a/templates/config.yml
+++ b/templates/config.yml
@@ -43,7 +43,7 @@ conda/infrastructure:
   # - src: templates/releases/RELEASE.md
   #   dst: RELEASE.md
   #   with:
-  #     canary-channel: https://anaconda.org/conda-canary
+  #     canary_channel: https://anaconda.org/conda-canary
   #     # CalVer placeholders
   #     placeholder: YY.M.PATCH
   #     placeholder_x: YY.M.x

--- a/templates/releases/RELEASE.md
+++ b/templates/releases/RELEASE.md
@@ -117,7 +117,7 @@ Let various interested parties know about the upcoming release; at minimum, cond
 
 ### Canary Builds for Manual Testing
 
-Once the release PRs are filed, successful canary builds will be available on `[[ canary-channel ]]/[[ repo.name ]]/files?channel=rc-[[ repo.name ]]-[[ placeholder_x ]]` for manual testing.
+Once the release PRs are filed, successful canary builds will be available on `[[ canary_channel ]]/[[ repo.name ]]/files?channel=rc-[[ repo.name ]]-[[ placeholder_x ]]` for manual testing.
 
 > [!NOTE]
 > You do not need to apply the `build::review` label for release PRs; every commit to the release branch builds and uploads canary builds to the respective `rc-` label.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to #1068

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
