### PR TITLE
Escape Jinja comment start string

### DIFF
--- a/templates/releases/RELEASE.md
+++ b/templates/releases/RELEASE.md
@@ -66,7 +66,7 @@ Placeholder for `[[ repo.name ]] [[ placeholder_x ]]` release.
 <summary><h4>Release week</h4></summary>
 
 - [ ] Create release PR (see [release process][process])
-- [ ] Create Zulip thread on [#releases][zulip]
+- [ ] Create Zulip thread on [[ '[#releases][zulip]' ]]
     - [ ] Announce `[[ placeholder ]]` in-progress
 - [ ] [Publish release][releases]
 - [ ] Merge `[[ placeholder_x ]]` back into `main`
@@ -95,7 +95,7 @@ If a patch release is necessary, reopen the original release issue and append th
 
 - [ ] <!-- list issues & PRs that need to be resolved here -->
 - [ ] Create release PR (see [release process][process])
-- [ ] Update Zulip thread on [#releases][zulip]
+- [ ] Update Zulip thread on [[ '[#releases][zulip]' ]]
     - [ ] Announce `[[ placeholder ]]` in-progress
 - [ ] [Publish release][releases]
 - [ ] Merge `[[ placeholder_x ]]` back into `main`


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Recent templating of the `RELEASE.md` have failed (see audit in https://github.com/conda/conda/pull/14515) because of the Zulip links added in #1090 & #1100 the templating fails since `[#` is defined as the comment start string in our Jinja templating engine.

We correct this by escaping the string, see https://jinja.palletsprojects.com/en/stable/templates/#escaping.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
