### PR TITLE
Change "table of contents" to "outline"

### DIFF
--- a/HOW_WE_USE_GITHUB.md
+++ b/HOW_WE_USE_GITHUB.md
@@ -47,7 +47,7 @@ This document seeks to outline how we as a community use GitHub Issues to track 
   - [Working on Issues](#working-on-issues)
 
 > [!NOTE]
-> This document is written in the style of an FAQ. For easier navigation, use [GitHub's table of contents feature][docs-toc].
+> This document is written in the style of an FAQ. For easier navigation, use [GitHub's Markdown outline][docs-toc].
 
 ## What is "Issue Sorting"?
 


### PR DESCRIPTION
GitHub calls the hamburger menu "outline" today.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Clearer to me.



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
