### PR TITLE
Add templates for check and prepare authors

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,6 @@ paths:
   templates/workflows/prepare-release.yml:
     ignore:
       - ^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$
+  templates/workflows/prepare-authors.yml:
+    ignore:
+      - ^invalid CRON format

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,7 +30,7 @@ jobs:
       statuses: write  # Required to publish the CLA commit status.
     steps:
       - name: Check CLA
-        uses: conda/actions/check-cla@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        uses: conda/actions/check-cla@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         with:
           # [required]
           # A token with ability to comment, label, and modify the commit status

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,7 +40,7 @@ jobs:
             days-before-issue-stale: 90
             days-before-issue-close: 21
     steps:
-      - uses: conda/actions/read-file@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+      - uses: conda/actions/read-file@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         id: read_messages
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,11 +33,11 @@ jobs:
           git config --global user.name 'Conda Bot'
           git config --global user.email '18747875+conda-bot@users.noreply.github.com'
 
-      - uses: conda/actions/combine-durations@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+      - uses: conda/actions/combine-durations@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         id: durations
         continue-on-error: true
 
-      - uses: conda/actions/template-files@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+      - uses: conda/actions/template-files@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         id: templates
         continue-on-error: true
 

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -55,6 +55,17 @@ conda/infrastructure:
   #   with:
   #     tests_workflow: Test
 
+  # [optional] validate .authors.yml on PRs
+  # - src: templates/workflows/check-authors.yml
+  #   dst: .github/workflows/check-authors.yml
+
+  # [optional] keep .authors.yml current (weekly PR)
+  # - src: templates/workflows/prepare-authors.yml
+  #   dst: .github/workflows/prepare-authors.yml
+  # For repos with a non-standard schedule, add:
+  #   with:
+  #     schedule: '0 4 * * 2'
+
   # [optional] general processes for the conda org
   - src: templates/HOW_WE_USE_GITHUB.md
     dst: HOW_WE_USE_GITHUB.md

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
-        uses: conda/actions/canary-release@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        uses: conda/actions/canary-release@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         env:
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
         with:

--- a/templates/workflows/check-authors.yml
+++ b/templates/workflows/check-authors.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Check Authors
-        uses: conda/actions/prepare-authors@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        uses: conda/actions/prepare-authors@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         with:
           mode: check
           since: tag

--- a/templates/workflows/check-authors.yml
+++ b/templates/workflows/check-authors.yml
@@ -1,0 +1,24 @@
+# edit this in [[ source.html_url ]]
+
+name: Check authors
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check Authors
+        uses: conda/actions/prepare-authors@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        with:
+          mode: check
+          since: tag

--- a/templates/workflows/check-news.yml
+++ b/templates/workflows/check-news.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Check News
-        uses: conda/actions/check-news@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        uses: conda/actions/check-news@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         with:
           skip-label: no-news
           require-pr-number: true

--- a/templates/workflows/prepare-authors.yml
+++ b/templates/workflows/prepare-authors.yml
@@ -1,0 +1,33 @@
+# edit this in [[ source.html_url ]]
+
+name: Prepare authors
+
+on:
+  # every Monday at 03:00 UTC
+  # https://crontab.guru/#0_3_*_*_1
+  schedule:
+    - cron: '[[ schedule | default("0 3 * * 1") ]]'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    if: '!github.event.repository.fork'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Prepare Authors
+        uses: conda/actions/prepare-authors@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        with:
+          token: ${{ secrets.SYNC_TOKEN }}
+          since: tag
+          base-branch: main

--- a/templates/workflows/prepare-authors.yml
+++ b/templates/workflows/prepare-authors.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Prepare Authors
-        uses: conda/actions/prepare-authors@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        uses: conda/actions/prepare-authors@d88418cd4e36358ba51e7c88f2d2d5edb9ac49e7 # v26.8.1
         with:
           token: ${{ secrets.SYNC_TOKEN }}
           since: tag

--- a/templates/workflows/prepare-authors.yml
+++ b/templates/workflows/prepare-authors.yml
@@ -3,8 +3,7 @@
 name: Prepare authors
 
 on:
-  # every Monday at 03:00 UTC
-  # https://crontab.guru/#0_3_*_*_1
+  # https://crontab.guru/#[[ schedule | default("0 3 * * 1") | replace(" ", "_") ]]
   schedule:
     - cron: '[[ schedule | default("0 3 * * 1") ]]'
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Following https://github.com/conda/actions/pull/470 for adding the check-authors and prepare-authors workflows, this PR adds an infrastructure template so that repos can opt in to using it.

I also added a yaml lint exception so that the Jinja syntax doesn't fail the cron syntax hint.

- [X] This PR depends on a new release of https://github.com/conda/actions once https://github.com/conda/actions/pull/501 is merged.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
