### PR TITLE
Improve errors for failing to create a fork

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -72,7 +72,7 @@ jobs:
           echo ::group::Fork debugging
           gh repo fork --clone=false --default-branch-only
           echo ::endgroup::
-          UPSTREAM="$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')"
+          UPSTREAM="$(gh api repos/{owner}/{repo}/forks --method POST -f default_branch_only=true --jq .full_name)"
           echo "UPSTREAM=${UPSTREAM}" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
           echo ::group::Fork debugging
           gh repo fork --clone=false --default-branch-only
           echo ::endgroup::
-          DOWNSTREAM="$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')"
+          DOWNSTREAM="$(gh api repos/{owner}/{repo}/forks --method POST -f default_branch_only=true --jq .full_name)"
           echo "DOWNSTREAM=${DOWNSTREAM}" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Create fork
         # no-op if the repository is already forked
         run: |
-          FORK="$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')"
+          FORK="$(gh api repos/{owner}/{repo}/forks --method POST -f default_branch_only=true --jq .full_name)"
           echo "FORK=${FORK}" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Although I'm not sure about full root cause, this change improves error reporting when creating a fork. This line is currently failing on runs with the failure of 

```
Error: Unable to process file command 'env' successfully.
Error: Invalid format 'Try'
```

I tested this command locally using a bash script. It replaces usage of awk and sed with the gh API more directly to create a fork, or return the current fork if it exists.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
